### PR TITLE
Slight modification to XML files to broaden update applicability (but long story, my bad)

### DIFF
--- a/wsuks/xml_files/get-config.xml
+++ b/wsuks/xml_files/get-config.xml
@@ -13,7 +13,24 @@
                         <Parameter />
                     </AuthPlugInInfo>
                 </AuthInfo>
-                <Properties />
+                <Properties>
+                    <ConfigurationProperty>
+                        <Name>MaxExtendedUpdatesPerRequest</Name>
+                        <Value>20</Value>
+                    </ConfigurationProperty>
+                    <ConfigurationProperty>
+                        <Name>ProtocolVersion</Name>
+                        <Value>3.2</Value>
+                    </ConfigurationProperty>
+                    <ConfigurationProperty>
+                        <Name>IsInventoryRequired</Name>
+                        <Value>0</Value>
+                    </ConfigurationProperty>
+                    <ConfigurationProperty>
+                        <Name>ClientReportingLevel</Name>
+                        <Value>2</Value>
+                    </ConfigurationProperty>
+                </Properties>
             </GetConfigResult>
         </GetConfigResponse>
     </s:Body>

--- a/wsuks/xml_files/sync-updates.xml
+++ b/wsuks/xml_files/sync-updates.xml
@@ -20,10 +20,7 @@
                         <Xml>&lt;UpdateIdentity UpdateID="{uuid1}" RevisionNumber="204"
                             /&gt;&lt;Properties UpdateType="Software" ExplicitlyDeployable="true"
                             AutoSelectOnWebSites="true"
-                            /&gt;&lt;Relationships&gt;&lt;Prerequisites&gt;&lt;AtLeastOne
-                            IsCategory="true"&gt;&lt;UpdateIdentity
-                            UpdateID="0fa1201d-4330-4fa8-8ae9-b877473b6441"
-                            /&gt;&lt;/AtLeastOne&gt;&lt;/Prerequisites&gt;&lt;BundledUpdates&gt;&lt;UpdateIdentity
+                            /&gt;&lt;Relationships&gt;&lt;BundledUpdates&gt;&lt;UpdateIdentity
                             UpdateID="{uuid2}" RevisionNumber="204"
                             /&gt;&lt;/BundledUpdates&gt;&lt;/Relationships&gt;</Xml>
                     </UpdateInfo>


### PR DESCRIPTION
Hello there!
As discussed with Neff, some people have reported issues with clients not pulling updates sometimes. Sorry in advance if this is too lengthy, but I wanted to share all my findings that lead to these suggested changes. The issue can be intermittent and hard to reproduce as well sometimes. [Similar things have been reported with the pywsus project as well](https://github.com/GoSecure/pywsus/issues/17), from which this project is inspired. 

After a lot of testing in the lab, the easiest "issue" to reproduce at will happens when clients have never been synced to a WSUS server before. I suspect this is common in a few people's labs where for example you would deploy an environment, let's say with Ludus, and try to reproduce the attack right away (whether using pywsus or wsuks) when the client has never been synced to WSUS before. What usually happens in that case is that the client sends a sequence of `GetConfig` -> `GetCookie` -> `SyncUpdates`, then doesn't go any further. No obvious error is shown either. Some people have reported seeing the `0x80240013` error, but this seems to be purely a duplicate error that happens when trying to pull the same update a second time, for example after it initially "failed" silently. Since wsuks randomizes the update IDs every time it's launched, simply restarting the server gets rid of the `0x80240013` error. I don't think this error code is related to the issue I have reproduced and tested. 

**Test setup**
DC: running Win2022
WSUS: running Win2022, domain-joined
WS01: running Win11 24H2, domain-joined
GPO pointing DC and WS01 to http://wsus.ludus.lab:8530, but clients were never synced (WSUS console empty)
*This is my snapshot state that I revert to between tests*

## sync-updates-xml
After chatting with the AI overlords as many people do nowadays, it was suspected that the update was being evaluated as non-applicable due to the category prerequisite missing on the client. It made sense, especially since the hardcoded category [seems related to WSUS/SCCM](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ff357803(v=vs.85)) and the client has never been synced. However, I had trouble finding evidence to back this claim, until I realized that setting the Windows Update client trace log level to `5`, instead of the often-suggested `4`, finally showed the details I was looking for.
```shell
reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Trace /v Level /t REG_DWORD /d 5 /f
```
This was visible in the client's ETW logs after trying to pull the update on either the Win2022 DC or the Win11 workstation:

<img width="996" height="176" alt="image" src="https://github.com/user-attachments/assets/77028610-dd7b-42d6-a615-608f1a897204" />

It is then clear that the prerequisite category hardcoded into the original `sync-updates.xml` file offered by the malicious WSUS server is missing from the client in that case (0fa1201d-4330-4fa8-8ae9-b877473b6441). Presumably, this category is subscribed to when the client is synced to WSUS/MECM, but we are working with a never-synced client here.

So, the first change made was simply to remove this prerequisite from `sync-updates.xml`, revert the lab to a clean state and try again. The behavior then changed, but more issues popped up:
- Win2022 DC: this client consistently failed to sync to wsuks with error `0x8024402a`
- Win11 workstation: this client would consistently fail with error `0x8024001d` 

## get-config.xml

For this one, the AI overlords initially suggested to populate the `<Properties>` element with actual protocol values instead of keeping it empty as it is in the original implementation. Digging back into the logs, I could see this on the Win2022 client:
<img width="1185" height="127" alt="image" src="https://github.com/user-attachments/assets/18683786-6b59-4e94-b8a7-72614461f36b" />

For the Windows 11 client, the behavior was slightly different, so maybe there is indeed some variance based on the OS used for this? the client logs showed a different category error. I could not explain what it means. I did not find meaningful information about this category.
<img width="1589" height="163" alt="image" src="https://github.com/user-attachments/assets/68b30f41-c6d9-470a-a0fc-2c7ba93a70df" />

What I can say is that configuring proper `<Properties>` in `get-config.xml` seems to alleviate both errors. Interestingly, taking a peek at the [WSUS spec](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wusp/b8a2ad1d-11c4-4b64-a2cc-12771fcb079b), we can see some hints as to why it could be helping. 
<img width="883" height="253" alt="image" src="https://github.com/user-attachments/assets/6a16e61c-2e6d-4c86-a6be-d6ec0051d1b5" />

`MaxExtendedUpdatesPerRequest` is apparently mandatory when sending a response to `GetConfig`, maybe this is why the Win2022 server was complaining? the other AI-suggested elements are also present as mandatory so I guess it helps to include them in the response (except `PackageServerShare`). I did not however play with these properties to see which ones could be omitted or not.
<img width="838" height="284" alt="image" src="https://github.com/user-attachments/assets/bcd02d55-516b-4638-9d4f-1e68fe8136c9" />

With both changes applied, unsynced clients *usually* pull the malicious update on the first try. I say usually because after repeatedly testing the same clients multiple times (with snapshot reverts in between to keep a clean state), the Windows 2022 seemed to ALWAYS work while the Windows 11 client seemed slightly more fragile for some reason. Some times, it seems that it went as far as `GetExtendedUpdateInfo`, but didn't install the update for some reason. Restarting `wsuks` (to randomize update IDs) and retrying the same thing then resulted in 2 updates installing together. I believe it is due to WSUS sync conflict/MITM woes, but I'm not 100% sure on this. Most times, it DOES work first try too (4 out of the 5 last tests).

## Synced clients

There are still a few questions I can't really answer:
- Why is a Win11 failing with a different, weird category error when removing the prerequisite?
- If the `GetConfigResponse` is malformed, then why does it work fine when the clients have been synced to WSUS before trying the attack?

I don't have an answer for those. However, I have tested the changes multiple times on the clients, both when previously synced to WSUS, or never synced to WSUS before, and they don't seem to hurt at all for synced clients. I believe it just helps for the attack to succeed when replicating the attack with clients that have never seen a WSUS server before by making the update more "broadly applicable". Maybe it is an issue that we are less likely to see in the real world where most of our targets will be already syncing with a live WSUS, but oh well, who knows. :) 